### PR TITLE
Added CHECKOUT_TARGET build arg to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:1.8-jessie
 
+ARG CHECKOUT_TARGET=master
+
 # TARGET={bootnode|fullnode|miningnode}
 ENV TARGET=fullnode
 
@@ -8,6 +10,8 @@ RUN mkdir -p /opt/go-ethereum
 RUN git clone https://github.com/ethereum/go-ethereum.git /opt/go-ethereum
 
 WORKDIR /opt/go-ethereum
+
+RUN git checkout $CHECKOUT_TARGET
 
 RUN make all
 


### PR DESCRIPTION
This allows specification of `go-ethereum` branch to build `go-ethereum` binaries from at Docker build time using the `--build-arg` parameter.